### PR TITLE
Support laravel >= 5.8 and >= 6.0 installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Laravel adapter for bref
 
+## Supported laravel versions
+
+| Version | Branch | Status   |
+| ---     | ---    | ---      |
+| < 5.8   | master | untested |
+| 5.8     | master | works    |
+| 6.x     | master | wip      |
+
 ## TODOs
 
 This is a small list of things (@TODO: move them to issues) 

--- a/src/Commands/SqsWorkCommand.php
+++ b/src/Commands/SqsWorkCommand.php
@@ -1,7 +1,10 @@
 <?php namespace Sikei\Bref\Sqs\Laravel\Commands;
 
 use Bref\Runtime\LambdaRuntime;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Queue\Console\WorkCommand;
+use Illuminate\Queue\Worker;
 use Sikei\Bref\Sqs\Laravel\Queue\Connector;
 use Sikei\Bref\Sqs\Laravel\Queue\Queue;
 
@@ -24,6 +27,20 @@ class SqsWorkCommand extends WorkCommand
     /** @var LambdaRuntime */
     protected $lambdaRuntime;
 
+    /** @var \Illuminate\Queue\Worker */
+    protected $worker;
+
+    /** @var \Illuminate\Contracts\Cache\Repository */
+    protected $cache;
+
+    public function __construct(Worker $worker, Cache $cache)
+    {
+        Command::__construct();
+
+        $this->cache = $cache;
+        $this->worker = $worker;
+    }
+
     public function handle()
     {
         $this->lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
@@ -38,7 +55,7 @@ class SqsWorkCommand extends WorkCommand
 
     protected function runWorker($connection, $queueName)
     {
-        $this->worker->setCache($this->laravel['cache']->driver());
+        $this->worker->setCache($this->cache);
 
         /** @var Queue $queue */
         $queue = $this->worker->getManager()->connection($connection);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,17 +4,19 @@ use Sikei\Bref\Sqs\Laravel\Commands\SqsWorkCommand;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
+    public function register()
     {
-        if ($this->app->runningInConsole()) {
-            $this->commands([
-                SqsWorkCommand::class,
-            ]);
-        }
+        $this->app->singleton('command.sqs.work', function ($app) {
+            return new SqsWorkCommand($app['queue.worker'], $app['cache.store']);
+        });
+
+        $this->commands(['command.sqs.work']);
+    }
+
+    public function provides()
+    {
+        return [
+            'command.sqs.work',
+        ];
     }
 }


### PR DESCRIPTION
Added a different way to extend the WorkCommand in order to support laravel >= 5.8 and 6.x installations. 

```
composer require christoph-kluge/bref-sqs-laravel:dev-support-laravel-58-and-6x
```

OR 

```
"require": {
        "christoph-kluge/bref-sqs-laravel": "dev-support-laravel-58-and-6x"
},
"minimum-stability": "dev"
```