### PR TITLE
Pass container and connection-name to laravel's SqsQueue

### DIFF
--- a/src/Commands/SqsWorkCommand.php
+++ b/src/Commands/SqsWorkCommand.php
@@ -68,6 +68,7 @@ class SqsWorkCommand extends WorkCommand
 
         /** @var Queue $queue */
         $queue = $this->worker->getManager()->connection($connection);
+        $queue->setContainer($this->laravel);
 
         while (true) {
             $this->lambdaRuntime->processNextEvent(function (array $event) use ($connection, $queueName, $queue) : array {

--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -1,5 +1,6 @@
 <?php namespace Sikei\Bref\Sqs\Laravel\Queue;
 
+use Illuminate\Container\Container;
 use Illuminate\Queue\Queue as BaseQueue;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
@@ -13,6 +14,20 @@ class Queue extends BaseQueue implements QueueContract
     public function __construct(SqsQueue $sqq)
     {
         $this->sqs = $sqq;
+    }
+
+    public function setContainer(Container $container)
+    {
+        $this->sqs->setContainer($container);
+
+        parent::setContainer($container);
+    }
+
+    public function setConnectionName($name)
+    {
+        $this->sqs->setConnectionName($name);
+
+        return parent::setConnectionName($name);
     }
 
     public function fill(array $event)


### PR DESCRIPTION
L8+ changed its internal behavior for the `Queue->push()` method to provider a better support for chained jobs.

This was not discovered before because the usage of `$this->container` was not necessary. It was directly pushig the jobs into SQS.

Fixes #11 