### PR TITLE
Added rest option to SqsWorkCommand for laravel version 8.32.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Homestead.yaml
 Homestead.json
 /.vagrant
 .phpunit.result.cache
+.idea

--- a/src/Commands/SqsWorkCommand.php
+++ b/src/Commands/SqsWorkCommand.php
@@ -25,6 +25,7 @@ class SqsWorkCommand extends WorkCommand
                             {--force : Force the worker to run even in maintenance mode}
                             {--memory=128 : The memory limit in megabytes}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
+                            {--rest=0 : Number of seconds to rest between jobs}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=1 : Number of times to attempt a job before logging it failed}';
 


### PR DESCRIPTION
Laravel version 8.32.0 add a new option to the `WorkCommand`. This breaks the worker.

Release note of Laravel 8.32.0: [https://github.com/laravel/framework/releases/tag/v8.32.0](https://github.com/laravel/framework/releases/tag/v8.32.0)

Commit in the `illuminate/queue` repository that added the `rest` option: [https://github.com/illuminate/queue/commit/17af31fe1361348513be7421f4319cfe62ea9652](https://github.com/illuminate/queue/commit/17af31fe1361348513be7421f4319cfe62ea9652)

I tested the changes in Laravel 8.34.0 with a queued mail.